### PR TITLE
Configureable attack keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Helper for your RPG fantasies to become the best Knight via Python
 - Enter auto pot thresholds and pot keys.
 
 ### Attack Settings
-- Enable R auto attack if you want it in.
+- Enable basic auto attack and auto targeting if you want it in. Enter the target or basic attack key in lower case. Basic attack key is pressed before every skill.
 - Classes and skills will be loaded from the `config/skill_data.yml` file. Enter any type of class skills and skills types in the file following example format to show your classes and skills here. Skill images can optionally be stored in `static/` folder to see them in GUI. Image names should follow `{class_name}_{skill_type}_{skill_name}` format.
 - Tick the skills you want to be used, enter their skill bar shortcuts and skill slot shortcuts. Example Skill bar `F4` Slot `5`.
 

--- a/utils/auto_attack.py
+++ b/utils/auto_attack.py
@@ -15,8 +15,9 @@ def auto_attack_function(config: dict) -> None:
                       if skill["enabled"] and not skill["buff"] and not skill["heal"]]
     shared.resume_attack_event.set()
     while config['auto_attack_toggle'] and not shared.stop_auto_attack_event.is_set():
-        # Continuously press 'Z' to target
-        pydirectinput.press('z')
+        # Continuously target if enabled
+        if attack_settings.get("enable_auto_target", False):
+            pydirectinput.press(config["attack_settings"]["auto_target_key"])
         time.sleep(0.01)
 
         # Execute selected skills
@@ -29,8 +30,9 @@ def auto_attack_function(config: dict) -> None:
             pydirectinput.press(skill["slot"])
             # Continuously press 'R' if enabled
             if attack_settings.get("enable_basic_attack", False):
-                pydirectinput.press('r')
-            pydirectinput.press('z')
+                pydirectinput.press(config["attack_settings"]["basic_attack_key"])
+            if attack_settings.get("enable_auto_target", False):
+                pydirectinput.press(config["attack_settings"]["auto_target_key"])
             # Increase delay between skill activations
             time.sleep(0.15)
 

--- a/utils/gui.py
+++ b/utils/gui.py
@@ -385,6 +385,59 @@ def create_gui() -> None:
     enable_basic_attack_checkbox.grid(row=row, column=0, columnspan=2, sticky='nsew', padx=5, pady=5)
     row += 1
 
+    # Basic Attack Key
+    tk.Label(attack_settings_top_frame, text="Basic Attack Key:", font=("Arial", 10)).grid(
+        row=row, column=0, sticky='e', padx=5, pady=4
+    )
+    basic_attack_key_var = tk.StringVar()
+    basic_attack_key_entry = tk.Entry(
+        attack_settings_top_frame,
+        textvariable=basic_attack_key_var
+    )
+    basic_attack_key_var.set(shared.config["attack_settings"].get("basic_attack_key", ""))
+    basic_attack_key_entry.grid(row=row, column=1, sticky='w', padx=5, pady=4)
+
+    # Enable Auto Target checkbox
+    row += 1
+    enable_auto_target_var = tk.BooleanVar()
+    enable_auto_target_checkbox = tk.Checkbutton(
+        attack_settings_top_frame,
+        text="Enable Auto Target",
+        variable=enable_auto_target_var,
+        command=lambda: shared.config["attack_settings"].__setitem__(
+            "enable_auto_target",
+            enable_auto_target_var.get()
+        )
+    )
+    enable_auto_target_var.set(shared.config["attack_settings"].get("enable_auto_target", False))
+    enable_auto_target_checkbox.grid(row=row, column=0, columnspan=2, sticky='nsew', padx=5, pady=5)
+
+    # Auto Target Key
+    row += 1
+    tk.Label(attack_settings_top_frame, text="Auto Target Key:", font=("Arial", 10)).grid(
+        row=row, column=0, sticky='e', padx=5, pady=4
+    )
+    auto_target_key_var = tk.StringVar()
+    auto_target_key_entry = tk.Entry(
+        attack_settings_top_frame,
+        textvariable=auto_target_key_var
+    )
+    auto_target_key_var.set(shared.config["attack_settings"].get("auto_target_key", ""))
+    auto_target_key_entry.grid(row=row, column=1, sticky='w', padx=5, pady=4)
+
+    # Update config on entry changes
+    basic_attack_key_var.trace_add("write", lambda *args: shared.config["attack_settings"].
+                                   __setitem__("basic_attack_key", basic_attack_key_var.get()))
+    auto_target_key_var.trace_add("write", lambda *args: shared.config["attack_settings"].
+                                  __setitem__("auto_target_key", auto_target_key_var.get()))
+    enable_auto_target_var.trace_add("write", lambda *args: shared.config["attack_settings"].
+                                     __setitem__("enable_auto_target", enable_auto_target_var.get()))
+    enable_basic_attack_var.trace_add("write", lambda *args: shared.config["attack_settings"].
+                                      __setitem__("enable_basic_attack", enable_basic_attack_var.get()))
+
+    # Increment the row again for the Select Class frame
+    row += 1
+
     # Create a frame to hold 'Select Class' label and combobox
     select_class_frame = tk.Frame(attack_settings_top_frame)
     select_class_frame.grid(row=row, column=0, columnspan=2, sticky='nsew', padx=5, pady=4)

--- a/utils/loader.py
+++ b/utils/loader.py
@@ -32,6 +32,7 @@ def load_config(config_file: str = "config/config.yml") -> dict:
 
         attack_settings = config.get("attack_settings", {})
         enable_basic_attack = attack_settings.get("enable_basic_attack", False)
+        enable_auto_target = attack_settings.get("enable_auto_target", False)
         selected_class = attack_settings.get("selected_class", None)
         skills = attack_settings.get("skills", [])
 
@@ -53,7 +54,10 @@ def load_config(config_file: str = "config/config.yml") -> dict:
             "attack_settings": {
                 "enable_basic_attack": enable_basic_attack,
                 "selected_class": selected_class,
-                "skills": skills
+                "skills": skills,
+                "enable_auto_target": enable_auto_target,
+                "basic_attack_key": attack_settings.get("basic_attack_key", 'r'),
+                "auto_target_key": attack_settings.get("auto_target_key", 'z')
             },
             "class_options": class_options
         }


### PR DESCRIPTION
Closes #23 , Custom Keys can be changed via GUI. Auto targeting is now also optional. You can manual target if ever wanted.
Current look:
![image](https://github.com/user-attachments/assets/860ed65d-ca0b-458b-99fd-50c740852304)
Tested.